### PR TITLE
feat: paste-from-clipboard support across all text inputs

### DIFF
--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -73,6 +73,14 @@ func (a *AgentOutput) Update(msg tea.Msg) tea.Cmd {
 
 	// If input is focused, forward messages to the input field
 	if a.input.Focused() {
+		// Intercept PasteMsg to sanitize and collapse newlines for single-line input
+		if pasteMsg, ok := msg.(tea.PasteMsg); ok {
+			sanitized := SanitizePaste(pasteMsg.Content)
+			// Collapse all newlines to single space for single-line textinput
+			sanitized = collapseNewlines(sanitized)
+			// Create new PasteMsg with sanitized content
+			msg = tea.PasteMsg{Content: sanitized}
+		}
 		var cmd tea.Cmd
 		a.input, cmd = a.input.Update(msg)
 		return cmd

--- a/internal/tui/agent_output_paste_teatest_test.go
+++ b/internal/tui/agent_output_paste_teatest_test.go
@@ -1,0 +1,236 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAgentOutput_PasteMultiline_CollapsesNewlines is a teatest integration test
+// that verifies multi-line paste content is collapsed to single line in agent chat input.
+func TestAgentOutput_PasteMultiline_CollapsesNewlines(t *testing.T) {
+	t.Parallel()
+
+	// Create agent output and initialize
+	ao := NewAgentOutput()
+	ao.UpdateSize(80, 24)
+
+	// Focus the input field
+	ao.SetInputFocused(true)
+	require.True(t, ao.input.Focused(), "input should be focused")
+
+	// Paste multi-line content
+	multiLineContent := "first line\nsecond line\n\nfourth line"
+	pasteMsg := tea.PasteMsg{Content: multiLineContent}
+
+	// Send the paste message
+	cmd := ao.Update(pasteMsg)
+	_ = cmd // command may be non-nil due to textarea updates
+
+	// Verify newlines were collapsed to single spaces
+	expected := "first line second line fourth line"
+	actual := ao.InputValue()
+	assert.Equal(t, expected, actual, "multi-line paste should be collapsed to single line")
+}
+
+// TestAgentOutput_PasteWithCRLF_CollapsesNewlines verifies CRLF line endings are handled correctly.
+func TestAgentOutput_PasteWithCRLF_CollapsesNewlines(t *testing.T) {
+	t.Parallel()
+
+	// Create agent output and initialize
+	ao := NewAgentOutput()
+	ao.UpdateSize(80, 24)
+
+	// Focus the input field
+	ao.SetInputFocused(true)
+
+	// Paste content with CRLF line endings (Windows-style)
+	crlfContent := "line1\r\nline2\r\nline3"
+	pasteMsg := tea.PasteMsg{Content: crlfContent}
+
+	// Send the paste message
+	ao.Update(pasteMsg)
+
+	// Verify CRLF sequences were collapsed to single spaces
+	expected := "line1 line2 line3"
+	actual := ao.InputValue()
+	assert.Equal(t, expected, actual, "CRLF line endings should be collapsed to single line")
+}
+
+// TestAgentOutput_PasteWithConsecutiveNewlines_CollapsesToSingleSpace verifies
+// that multiple consecutive newlines are collapsed to a single space.
+func TestAgentOutput_PasteWithConsecutiveNewlines_CollapsesToSingleSpace(t *testing.T) {
+	t.Parallel()
+
+	// Create agent output and initialize
+	ao := NewAgentOutput()
+	ao.UpdateSize(80, 24)
+
+	// Focus the input field
+	ao.SetInputFocused(true)
+
+	// Paste content with multiple consecutive newlines
+	content := "line1\n\n\n\nline2"
+	pasteMsg := tea.PasteMsg{Content: content}
+
+	// Send the paste message
+	ao.Update(pasteMsg)
+
+	// Verify consecutive newlines were collapsed to single space
+	expected := "line1 line2"
+	actual := ao.InputValue()
+	assert.Equal(t, expected, actual, "consecutive newlines should be collapsed to single space")
+}
+
+// TestAgentOutput_PasteWithMixedWhitespace_CollapsesCorrectly verifies
+// that mixed whitespace (newlines, tabs, spaces) is handled correctly.
+func TestAgentOutput_PasteWithMixedWhitespace_CollapsesCorrectly(t *testing.T) {
+	t.Parallel()
+
+	// Create agent output and initialize
+	ao := NewAgentOutput()
+	ao.UpdateSize(80, 24)
+
+	// Focus the input field
+	ao.SetInputFocused(true)
+
+	// Paste content with mixed whitespace - tabs are preserved by SanitizePaste,
+	// but textinput may convert them to spaces
+	content := "line1\n\tindented\nline2"
+	pasteMsg := tea.PasteMsg{Content: content}
+
+	// Send the paste message
+	ao.Update(pasteMsg)
+
+	// Verify: newlines collapsed to spaces
+	// Tabs may be converted to spaces by textinput, so we check for either format
+	actual := ao.InputValue()
+	// Should contain "line1" followed by whitespace followed by "indented" followed by whitespace followed by "line2"
+	assert.Contains(t, actual, "line1", "should contain line1")
+	assert.Contains(t, actual, "indented", "should contain indented")
+	assert.Contains(t, actual, "line2", "should contain line2")
+	assert.NotContains(t, actual, "\n", "should not contain newlines")
+}
+
+// TestAgentOutput_PasteMultiline_WhenNotFocused_NoChange verifies
+// that paste is ignored when input is not focused.
+func TestAgentOutput_PasteMultiline_WhenNotFocused_NoChange(t *testing.T) {
+	t.Parallel()
+
+	// Create agent output and initialize
+	ao := NewAgentOutput()
+	ao.UpdateSize(80, 24)
+
+	// Ensure input is NOT focused
+	ao.SetInputFocused(false)
+	require.False(t, ao.input.Focused(), "input should not be focused")
+
+	// Paste multi-line content
+	multiLineContent := "line1\nline2\nline3"
+	pasteMsg := tea.PasteMsg{Content: multiLineContent}
+
+	// Send the paste message
+	cmd := ao.Update(pasteMsg)
+
+	// Verify no command returned and no change to input
+	assert.Nil(t, cmd, "should return nil command when input not focused")
+	assert.Equal(t, "", ao.InputValue(), "input should remain empty when not focused")
+}
+
+// TestAgentOutput_PasteMultiline_WithSanitization verifies
+// that paste content is both sanitized and has newlines collapsed.
+func TestAgentOutput_PasteMultiline_WithSanitization(t *testing.T) {
+	t.Parallel()
+
+	// Create agent output and initialize
+	ao := NewAgentOutput()
+	ao.UpdateSize(80, 24)
+
+	// Focus the input field
+	ao.SetInputFocused(true)
+
+	// Paste content with newlines, ANSI codes, and null bytes
+	content := "\x1b[31mred\x1b[0m\nline1\x00\nline2"
+	pasteMsg := tea.PasteMsg{Content: content}
+
+	// Send the paste message
+	ao.Update(pasteMsg)
+
+	// Verify: ANSI codes stripped, null bytes removed, newlines collapsed
+	expected := "red line1 line2"
+	actual := ao.InputValue()
+	assert.Equal(t, expected, actual, "content should be sanitized and newlines collapsed")
+}
+
+// TestAgentOutput_PasteEmptyContent_HandlesGracefully verifies
+// that empty paste content is handled gracefully.
+func TestAgentOutput_PasteEmptyContent_HandlesGracefully(t *testing.T) {
+	t.Parallel()
+
+	// Create agent output and initialize
+	ao := NewAgentOutput()
+	ao.UpdateSize(80, 24)
+
+	// Focus the input field
+	ao.SetInputFocused(true)
+
+	// Paste empty content
+	pasteMsg := tea.PasteMsg{Content: ""}
+
+	// Send the paste message - should not panic
+	cmd := ao.Update(pasteMsg)
+
+	// Verify empty result
+	assert.Equal(t, "", ao.InputValue(), "empty paste should result in empty input")
+	_ = cmd
+}
+
+// TestAgentOutput_PasteMultiline_LargeContent verifies
+// that large multi-line paste content is handled correctly.
+func TestAgentOutput_PasteMultiline_LargeContent(t *testing.T) {
+	t.Parallel()
+
+	// Create agent output and initialize
+	ao := NewAgentOutput()
+	ao.UpdateSize(80, 24)
+
+	// Focus the input field
+	ao.SetInputFocused(true)
+
+	// Create large multi-line content (100 lines)
+	var content string
+	for i := 0; i < 100; i++ {
+		if i > 0 {
+			content += "\n"
+		}
+		content += "line"
+	}
+
+	pasteMsg := tea.PasteMsg{Content: content}
+
+	// Send the paste message - should not panic or timeout
+	done := make(chan bool, 1)
+	go func() {
+		ao.Update(pasteMsg)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Success - update completed
+	case <-time.After(2 * time.Second):
+		t.Fatal("paste handling timed out for large content")
+	}
+
+	// Verify all newlines were collapsed to single spaces
+	// Result should be "line line line ..." (100 times)
+	expected := "line"
+	for i := 1; i < 100; i++ {
+		expected += " line"
+	}
+	actual := ao.InputValue()
+	assert.Equal(t, expected, actual, "large multi-line paste should be collapsed correctly")
+}

--- a/internal/tui/agent_paste_test.go
+++ b/internal/tui/agent_paste_test.go
@@ -1,0 +1,68 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgentOutput_Paste_CollapsesNewlines(t *testing.T) {
+	agent := NewAgentOutput()
+	agent.UpdateSize(80, 24)
+	agent.SetInputFocused(true)
+
+	// Paste multi-line text
+	pasteContent := "line1\nline2\n\nline3"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	agent.Update(pasteMsg)
+
+	// Verify newlines were collapsed to single space
+	assert.Equal(t, "line1 line2 line3", agent.InputValue())
+}
+
+func TestAgentOutput_Paste_SanitizesContent(t *testing.T) {
+	agent := NewAgentOutput()
+	agent.UpdateSize(80, 24)
+	agent.SetInputFocused(true)
+
+	// Paste content with ANSI codes and null bytes
+	pasteContent := "\x1b[31mred\x1b[0m text\x00"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	agent.Update(pasteMsg)
+
+	// Verify ANSI codes and null bytes were removed
+	assert.Equal(t, "red text", agent.InputValue())
+}
+
+func TestAgentOutput_Paste_WhenNotFocused_NoOp(t *testing.T) {
+	agent := NewAgentOutput()
+	agent.UpdateSize(80, 24)
+	agent.SetInputFocused(false)
+
+	// Paste content while input is not focused
+	pasteContent := "pasted text"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	agent.Update(pasteMsg)
+
+	// Input should remain empty since it's not focused
+	assert.Equal(t, "", agent.InputValue())
+}
+
+func TestAgentOutput_Paste_CombinedSanitizationAndNewlineCollapse(t *testing.T) {
+	agent := NewAgentOutput()
+	agent.UpdateSize(80, 24)
+	agent.SetInputFocused(true)
+
+	// Paste content with newlines, ANSI codes, and CRLF
+	pasteContent := "\x1b[1mbold\x1b[0m\r\nline1\n\nline2\x00"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	agent.Update(pasteMsg)
+
+	// Verify all transformations: ANSI stripped, CRLF->LF then newlines collapsed, null bytes removed
+	assert.Equal(t, "bold line1 line2", agent.InputValue())
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -548,27 +548,40 @@ func (a *App) handlePaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 	// Sanitize pasted content
 	content := SanitizePaste(msg.Content)
 
-	// 1. Note input modal gets priority when visible
+	// 1. Dialog has no text input — consume paste
+	if a.dialog.IsVisible() {
+		return a, nil
+	}
+
+	// 2. Read-only modals have no text input — consume paste
+	if a.taskModal != nil && a.taskModal.IsVisible() {
+		return a, nil
+	}
+	if a.noteModal != nil && a.noteModal.IsVisible() {
+		return a, nil
+	}
+
+	// 3. Note input modal gets priority when visible
 	if a.noteInputModal != nil && a.noteInputModal.IsVisible() {
 		return a, a.noteInputModal.Update(tea.PasteMsg{Content: content})
 	}
 
-	// 2. Task input modal gets priority when visible
+	// 4. Task input modal gets priority when visible
 	if a.taskInputModal != nil && a.taskInputModal.IsVisible() {
 		return a, a.taskInputModal.Update(tea.PasteMsg{Content: content})
 	}
 
-	// 3. Subagent modal gets priority when visible
+	// 5. Subagent modal gets priority when visible
 	if a.subagentModal != nil {
 		return a, a.subagentModal.Update(tea.PasteMsg{Content: content})
 	}
 
-	// 4. Logs has no text input, so paste is no-op when logs are visible
+	// 6. Logs has no text input, so paste is no-op when logs are visible
 	if a.logsVisible {
 		return a, nil
 	}
 
-	// 5. Delegate to dashboard for focused component handling
+	// 7. Delegate to dashboard for focused component handling
 	return a, a.dashboard.Update(tea.PasteMsg{Content: content})
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -931,10 +931,11 @@ func (a *App) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		toastContent := a.toast.View(area.Dx(), area.Dy())
 		if toastContent != "" {
 			// Calculate position at bottom-right with 1 cell padding from edges
-			// Position above the status bar (area.Max.Y - 2)
+			// Position above the status bar (area.Max.Y - 1 - contentHeight)
 			contentWidth := lipglossv2.Width(toastContent)
+			contentHeight := lipglossv2.Height(toastContent)
 			toastX := area.Max.X - contentWidth - 1
-			toastY := area.Max.Y - 2
+			toastY := area.Max.Y - 1 - contentHeight
 			if toastX < area.Min.X {
 				toastX = area.Min.X
 			}
@@ -943,7 +944,7 @@ func (a *App) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 			}
 			toastArea := uv.Rectangle{
 				Min: uv.Position{X: toastX, Y: toastY},
-				Max: uv.Position{X: toastX + contentWidth, Y: toastY + lipglossv2.Height(toastContent)},
+				Max: uv.Position{X: toastX + contentWidth, Y: toastY + contentHeight},
 			}
 			uv.NewStyledString(toastContent).Draw(scr, toastArea)
 		}

--- a/internal/tui/app_paste_teatest_test.go
+++ b/internal/tui/app_paste_teatest_test.go
@@ -1,0 +1,393 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// generateLongString generates a string of specified length using repeated pattern
+func generateLongString(length int) string {
+	pattern := "abcdefghijklmnopqrstuvwxyz0123456789"
+	result := make([]rune, length)
+	for i := 0; i < length; i++ {
+		result[i] = rune(pattern[i%len(pattern)])
+	}
+	return string(result)
+}
+
+// TestApp_PasteExceedsCharLimit_TruncatesAndShowsToast verifies that when
+// pasting content exceeding the 500 char limit into TaskInputModal,
+// the content is truncated and a toast notification is shown.
+func TestApp_PasteExceedsCharLimit_TruncatesAndShowsToast(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show the task input modal
+	app.taskInputModal.Show()
+
+	// Create paste content of 600 chars (exceeds 500 limit)
+	pasteContent := generateLongString(600)
+
+	// Send paste message through App's handlePaste
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// The command should contain a batch with textarea update + toast
+	if cmd == nil {
+		t.Fatal("Expected command from paste handling, got nil")
+	}
+
+	// Execute the command to get messages
+	msg := cmd()
+	if msg == nil {
+		t.Fatal("Expected message from paste command, got nil")
+	}
+
+	// Check for batch message containing both textarea update and toast
+	batchMsg, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Expected BatchMsg from paste handling, got %T", msg)
+	}
+
+	// Look for ShowToastMsg in the batch
+	var toastFound bool
+	var toastText string
+	for _, c := range batchMsg {
+		if c != nil {
+			innerMsg := c()
+			if tm, ok := innerMsg.(ShowToastMsg); ok {
+				toastFound = true
+				toastText = tm.Text
+				break
+			}
+		}
+	}
+
+	if !toastFound {
+		t.Error("Expected ShowToastMsg in batch, but not found")
+	}
+
+	expectedToast := "100 chars truncated"
+	if toastText != expectedToast {
+		t.Errorf("Expected toast message '%s', got: %s", expectedToast, toastText)
+	}
+
+	// Verify content was truncated to 500 chars
+	value := app.taskInputModal.textarea.Value()
+	runeCount := len([]rune(value))
+	if runeCount != 500 {
+		t.Errorf("Expected textarea to contain 500 chars (truncated), got: %d", runeCount)
+	}
+
+	// Content should be first 500 chars of original
+	expectedContent := string([]rune(pasteContent)[:500])
+	if value != expectedContent {
+		t.Error("Truncated content doesn't match expected")
+	}
+}
+
+// TestApp_PasteIntoPartiallyFilled_TruncatesCorrectly verifies that when
+// textarea already has content, paste is truncated correctly based on remaining space.
+func TestApp_PasteIntoPartiallyFilled_TruncatesCorrectly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show the task input modal
+	app.taskInputModal.Show()
+
+	// Set initial content to 400 chars (100 chars remaining space)
+	initialContent := generateLongString(400)
+	app.taskInputModal.textarea.SetValue(initialContent)
+
+	// Paste 300 chars - only 100 should fit, 200 truncated
+	pasteContent := generateLongString(300)
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Execute the command
+	msg := cmd()
+	batchMsg, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Expected BatchMsg, got %T", msg)
+	}
+
+	// Look for toast message
+	var toastFound bool
+	var toastText string
+	for _, c := range batchMsg {
+		if c != nil {
+			innerMsg := c()
+			if tm, ok := innerMsg.(ShowToastMsg); ok {
+				toastFound = true
+				toastText = tm.Text
+				break
+			}
+		}
+	}
+
+	if !toastFound {
+		t.Error("Expected ShowToastMsg for truncated paste")
+	}
+
+	expectedToast := "200 chars truncated"
+	if toastText != expectedToast {
+		t.Errorf("Expected toast message '%s', got: %s", expectedToast, toastText)
+	}
+
+	// Content should be at limit (500 chars total)
+	value := app.taskInputModal.textarea.Value()
+	runeCount := len([]rune(value))
+	if runeCount != 500 {
+		t.Errorf("Expected textarea to contain 500 chars total, got: %d", runeCount)
+	}
+}
+
+// TestApp_PasteWhenFull_ShowsToastOnly verifies that when textarea is at the
+// limit, paste shows toast but doesn't add content.
+func TestApp_PasteWhenFull_ShowsToastOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show the task input modal
+	app.taskInputModal.Show()
+
+	// Fill textarea to exactly 500 chars
+	fullContent := generateLongString(500)
+	app.taskInputModal.textarea.SetValue(fullContent)
+
+	// Try to paste more content
+	pasteContent := "This should not be added"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Execute the command
+	msg := cmd()
+
+	// When textarea is full, we should get a ShowToastMsg directly (not a batch)
+	toastMsg, ok := msg.(ShowToastMsg)
+	if !ok {
+		t.Fatalf("Expected ShowToastMsg when pasting into full textarea, got %T", msg)
+	}
+
+	expectedToast := "24 chars truncated"
+	if toastMsg.Text != expectedToast {
+		t.Errorf("Expected toast message '%s', got: %s", expectedToast, toastMsg.Text)
+	}
+
+	// Content should still be exactly 500 chars
+	value := app.taskInputModal.textarea.Value()
+	if value != fullContent {
+		t.Error("Content should not have changed when pasting into full textarea")
+	}
+}
+
+// TestApp_PasteWithinLimit_NoToast verifies that when pasting content
+// within the char limit, no toast is shown.
+func TestApp_PasteWithinLimit_NoToast(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show the task input modal
+	app.taskInputModal.Show()
+
+	// Paste 100 chars - should fit within 500 limit
+	pasteContent := "This is a test task content that is well within the character limit of 500 characters."
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Execute the command
+	msg := cmd()
+
+	// Check for ShowToastMsg (should NOT be present)
+	var toastFound bool
+	if batchMsg, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batchMsg {
+			if c != nil {
+				innerMsg := c()
+				if _, ok := innerMsg.(ShowToastMsg); ok {
+					toastFound = true
+					break
+				}
+			}
+		}
+	} else if _, ok := msg.(ShowToastMsg); ok {
+		toastFound = true
+	}
+
+	if toastFound {
+		t.Error("Expected no toast for paste within limit")
+	}
+
+	// Content should be inserted unchanged
+	value := app.taskInputModal.textarea.Value()
+	if !strings.Contains(value, "test task content") {
+		t.Errorf("Expected textarea to contain pasted content, got: %s", value)
+	}
+}
+
+// TestApp_PasteNoteModalExceedsLimit_TruncatesAndShowsToast verifies that
+// NoteInputModal also truncates and shows toast when paste exceeds limit.
+func TestApp_PasteNoteModalExceedsLimit_TruncatesAndShowsToast(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show the note input modal (has priority over task modal)
+	app.noteInputModal.Show()
+
+	// Create paste content of 600 chars (exceeds 500 limit)
+	pasteContent := generateLongString(600)
+
+	// Send paste message through App's handlePaste
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Execute the command
+	msg := cmd()
+	batchMsg, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Expected BatchMsg, got %T", msg)
+	}
+
+	// Look for toast message
+	var toastFound bool
+	var toastText string
+	for _, c := range batchMsg {
+		if c != nil {
+			innerMsg := c()
+			if tm, ok := innerMsg.(ShowToastMsg); ok {
+				toastFound = true
+				toastText = tm.Text
+				break
+			}
+		}
+	}
+
+	if !toastFound {
+		t.Error("Expected ShowToastMsg for truncated paste in note modal")
+	}
+
+	expectedToast := "100 chars truncated"
+	if toastText != expectedToast {
+		t.Errorf("Expected toast message '%s', got: %s", expectedToast, toastText)
+	}
+
+	// Content should be truncated to 500 chars
+	value := app.noteInputModal.textarea.Value()
+	runeCount := len([]rune(value))
+	if runeCount != 500 {
+		t.Errorf("Expected textarea to contain 500 chars (truncated), got: %d", runeCount)
+	}
+}
+
+// TestApp_ToastIntegration_ShowsAndDismisses verifies that when ShowToastMsg
+// is sent to App.Update, the toast is shown and can be dismissed.
+func TestApp_ToastIntegration_ShowsAndDismisses(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Initially toast should not be visible
+	if app.toast.IsVisible() {
+		t.Error("Toast should not be visible initially")
+	}
+
+	// Send ShowToastMsg to App.Update
+	showMsg := ShowToastMsg{Text: "50 chars truncated"}
+	_, cmd := app.Update(showMsg)
+
+	// Command should schedule dismissal
+	if cmd == nil {
+		t.Error("Expected dismissal command from toast show")
+	}
+
+	// Toast should now be visible
+	if !app.toast.IsVisible() {
+		t.Error("Toast should be visible after ShowToastMsg")
+	}
+
+	if app.toast.GetMessage() != "50 chars truncated" {
+		t.Errorf("Expected toast message '50 chars truncated', got: %s", app.toast.GetMessage())
+	}
+
+	// Simulate dismissal by sending ToastDismissMsg
+	_, _ = app.Update(ToastDismissMsg{})
+
+	// Toast should no longer be visible
+	if app.toast.IsVisible() {
+		t.Error("Toast should not be visible after dismissal")
+	}
+}
+
+// TestApp_PasteWithSanitizationAndTruncation verifies that paste content
+// is both sanitized and truncated when necessary.
+func TestApp_PasteWithSanitizationAndTruncation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show the task input modal
+	app.taskInputModal.Show()
+
+	// Create paste content with ANSI codes and exceeding limit
+	// 500 chars of normal content + ANSI codes + 100 more chars
+	normalContent := generateLongString(500)
+	pasteContent := "\x1b[31m" + normalContent + "\x1b[0m" + generateLongString(100)
+
+	// Send paste message
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Execute the command
+	msg := cmd()
+	batchMsg, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Expected BatchMsg, got %T", msg)
+	}
+
+	// Look for toast message (100 chars should be truncated)
+	var toastFound bool
+	for _, c := range batchMsg {
+		if c != nil {
+			innerMsg := c()
+			if tm, ok := innerMsg.(ShowToastMsg); ok {
+				toastFound = true
+				expectedToast := "100 chars truncated"
+				if tm.Text != expectedToast {
+					t.Errorf("Expected toast '%s', got: %s", expectedToast, tm.Text)
+				}
+				break
+			}
+		}
+	}
+
+	if !toastFound {
+		t.Error("Expected ShowToastMsg for truncated paste")
+	}
+
+	// Verify content is at 500 char limit and ANSI codes are stripped
+	value := app.taskInputModal.textarea.Value()
+	runeCount := len([]rune(value))
+	if runeCount != 500 {
+		t.Errorf("Expected textarea to contain 500 chars, got: %d", runeCount)
+	}
+
+	// ANSI codes should be stripped
+	if strings.Contains(value, "\x1b[") {
+		t.Error("ANSI escape codes should be stripped from pasted content")
+	}
+}

--- a/internal/tui/app_paste_teatest_test.go
+++ b/internal/tui/app_paste_teatest_test.go
@@ -323,8 +323,10 @@ func TestApp_ToastIntegration_ShowsAndDismisses(t *testing.T) {
 		t.Errorf("Expected toast message '50 chars truncated', got: %s", app.toast.GetMessage())
 	}
 
-	// Simulate dismissal by sending ToastDismissMsg
-	_, _ = app.Update(ToastDismissMsg{})
+	// Simulate dismissal by executing the dismiss command
+	// (which will include the correct generation)
+	dismissMsg := cmd()
+	_, _ = app.Update(dismissMsg)
 
 	// Toast should no longer be visible
 	if app.toast.IsVisible() {

--- a/internal/tui/app_paste_test.go
+++ b/internal/tui/app_paste_test.go
@@ -1,0 +1,151 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestApp_HandlePaste_RoutesToNoteInputModal(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show the note input modal
+	app.noteInputModal.Show()
+
+	// Send paste message - should not panic and should route to modal
+	pasteMsg := tea.PasteMsg{Content: "pasted note content"}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Modal's Update returns a command (may be nil if textarea doesn't have focus yet)
+	// The important thing is the routing happens without panic
+	_ = cmd
+}
+
+func TestApp_HandlePaste_RoutesToTaskInputModal(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show the task input modal
+	app.taskInputModal.Show()
+
+	// Send paste message - should not panic and should route to modal
+	pasteMsg := tea.PasteMsg{Content: "pasted task content"}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Modal's Update returns a command (may be nil if textarea doesn't have focus yet)
+	_ = cmd
+}
+
+func TestApp_HandlePaste_RoutesToSubagentModal(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Create and show subagent modal
+	app.subagentModal = NewSubagentModal("test-session", "explore", "/tmp")
+
+	// Send paste message - should not panic and should route to modal
+	pasteMsg := tea.PasteMsg{Content: "pasted subagent content"}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Subagent modal may or may not return a command - the important thing is no panic
+	_ = cmd
+}
+
+func TestApp_HandlePaste_NoOpWhenLogsVisible(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Make logs visible
+	app.logsVisible = true
+
+	// Send paste message
+	pasteMsg := tea.PasteMsg{Content: "pasted content"}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Verify no command is returned (paste is no-op in logs)
+	if cmd != nil {
+		t.Error("expected nil command when logs visible, got command")
+	}
+}
+
+func TestApp_HandlePaste_RoutesToDashboard(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Ensure no modals are visible and logs are not visible
+	app.logsVisible = false
+
+	// Send paste message - should not panic and should route to dashboard
+	pasteMsg := tea.PasteMsg{Content: "pasted dashboard content"}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Dashboard may or may not return a command - the important thing is no panic
+	_ = cmd
+}
+
+func TestApp_HandlePaste_SanitizesContent(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show note input modal
+	app.noteInputModal.Show()
+
+	// Send paste with ANSI escape codes - should not panic
+	pasteMsg := tea.PasteMsg{Content: "\x1b[31mcolored\x1b[0m text"}
+	app.handlePaste(pasteMsg)
+
+	// The sanitization happens before forwarding, so the content
+	// should be "colored text" when received by the modal
+	// (actual verification of sanitized content would require
+	//  inspecting the modal's textarea state)
+}
+
+func TestApp_HandlePaste_Priority_NoteOverTask(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show both modals
+	app.noteInputModal.Show()
+	app.taskInputModal.Show()
+
+	// Send paste message - should not panic
+	pasteMsg := tea.PasteMsg{Content: "pasted content"}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Should route to noteInputModal (priority) without panic
+	_ = cmd
+}
+
+func TestApp_HandlePaste_Priority_TaskOverSubagent(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Show task input modal and create subagent modal
+	app.taskInputModal.Show()
+	app.subagentModal = NewSubagentModal("test", "explore", "/tmp")
+
+	// Send paste message - should not panic
+	pasteMsg := tea.PasteMsg{Content: "pasted content"}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Should route to taskInputModal (priority) without panic
+	_ = cmd
+}
+
+func TestApp_HandlePaste_Priority_SubagentOverDashboard(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(ctx, nil, "test-session", "/tmp", t.TempDir(), nil, nil, nil)
+
+	// Create subagent modal and ensure no text modals visible
+	app.subagentModal = NewSubagentModal("test", "explore", "/tmp")
+	app.logsVisible = false
+
+	// Send paste message - should not panic
+	pasteMsg := tea.PasteMsg{Content: "pasted content"}
+	_, cmd := app.handlePaste(pasteMsg)
+
+	// Should route to subagentModal (priority over dashboard) without panic
+	_ = cmd
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -55,6 +55,13 @@ func (d *Dashboard) Update(msg tea.Msg) tea.Cmd {
 			return d.agentOutput.Update(msg)
 		}
 		return nil
+	case tea.PasteMsg:
+		// Forward paste messages to AgentOutput when input is focused
+		if d.focusPane == FocusInput && d.agentOutput != nil {
+			return d.agentOutput.Update(msg)
+		}
+		return nil
+
 	case tea.KeyPressMsg:
 		// Global 'i' key: focus input from any state
 		if msg.String() == "i" && d.focusPane != FocusInput {

--- a/internal/tui/note_input_modal.go
+++ b/internal/tui/note_input_modal.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -183,6 +184,15 @@ func (m *NoteInputModal) Update(msg tea.Msg) tea.Cmd {
 		return nil
 	}
 
+	// Handle paste messages when textarea is focused
+	if pasteMsg, ok := msg.(tea.PasteMsg); ok {
+		if m.focus == focusTextarea {
+			return m.handlePaste(pasteMsg)
+		}
+		// Paste when textarea not focused is a no-op
+		return nil
+	}
+
 	// Handle key presses
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
 		switch keyMsg.String() {
@@ -243,6 +253,46 @@ func (m *NoteInputModal) Update(msg tea.Msg) tea.Cmd {
 	}
 
 	return nil
+}
+
+// handlePaste processes a paste message for the textarea with char limit enforcement.
+// If the paste would exceed the 500 char limit, it truncates the content and shows a toast.
+func (m *NoteInputModal) handlePaste(msg tea.PasteMsg) tea.Cmd {
+	currentValue := m.textarea.Value()
+	currentLen := len([]rune(currentValue))
+	pasteContent := msg.Content
+	pasteLen := len([]rune(pasteContent))
+	charLimit := m.textarea.CharLimit
+
+	// Calculate how much we can fit
+	remainingSpace := charLimit - currentLen
+	if remainingSpace <= 0 {
+		// No space left - show toast and don't paste
+		return func() tea.Msg {
+			return ShowToastMsg{Text: fmt.Sprintf("%d chars truncated", pasteLen)}
+		}
+	}
+
+	if pasteLen > remainingSpace {
+		// Truncate the paste content
+		truncatedRunes := []rune(pasteContent)[:remainingSpace]
+		truncatedContent := string(truncatedRunes)
+		truncatedCount := pasteLen - remainingSpace
+
+		// Forward truncated paste to textarea
+		var cmd tea.Cmd
+		m.textarea, cmd = m.textarea.Update(tea.PasteMsg{Content: truncatedContent})
+
+		// Return batch command with textarea update + toast
+		return tea.Batch(cmd, func() tea.Msg {
+			return ShowToastMsg{Text: fmt.Sprintf("%d chars truncated", truncatedCount)}
+		})
+	}
+
+	// No truncation needed - forward original paste to textarea
+	var cmd tea.Cmd
+	m.textarea, cmd = m.textarea.Update(tea.PasteMsg{Content: pasteContent})
+	return cmd
 }
 
 // submit returns a command that creates a CreateNoteMsg.

--- a/internal/tui/note_input_modal_paste_test.go
+++ b/internal/tui/note_input_modal_paste_test.go
@@ -1,0 +1,237 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// extractToastMsg executes a command and returns any ShowToastMsg found.
+// Handles both single commands and batched commands.
+func extractToastMsg(cmd tea.Cmd) *ShowToastMsg {
+	if cmd == nil {
+		return nil
+	}
+
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+
+	// Check if it's a batch message
+	if batchMsg, ok := msg.(tea.BatchMsg); ok {
+		// BatchMsg is a slice of commands, execute each to find ShowToastMsg
+		for _, c := range batchMsg {
+			if c != nil {
+				innerMsg := c()
+				if tm, ok := innerMsg.(ShowToastMsg); ok {
+					return &tm
+				}
+			}
+		}
+	} else if tm, ok := msg.(ShowToastMsg); ok {
+		return &tm
+	}
+
+	return nil
+}
+
+// TestNoteInputModal_PasteWithinLimit_NoTruncation tests that paste content
+// within the char limit is forwarded without modification.
+func TestNoteInputModal_PasteWithinLimit_NoTruncation(t *testing.T) {
+	modal := NewNoteInputModal()
+	modal.Show()
+
+	// Initial content is empty (0 chars)
+	// Paste 100 chars - should fit within 500 limit
+	pasteContent := "This is a test note content that is well within the character limit of 500 characters."
+
+	// Create paste message
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// Execute command to get any messages
+	toastMsg := extractToastMsg(cmd)
+
+	// No toast should be shown (no truncation)
+	if toastMsg != nil {
+		t.Errorf("Expected no toast for paste within limit, got: %s", toastMsg.Text)
+	}
+
+	// Content should be inserted
+	if modal.textarea.Value() != pasteContent {
+		t.Errorf("Expected textarea to contain pasted content, got: %s", modal.textarea.Value())
+	}
+}
+
+// TestNoteInputModal_PasteExceedsLimit_Truncates tests that paste content
+// exceeding the char limit is truncated and a toast is shown.
+func TestNoteInputModal_PasteExceedsLimit_Truncates(t *testing.T) {
+	modal := NewNoteInputModal()
+	modal.Show()
+
+	// Initial content is empty (0 chars)
+	// Create paste content of 600 chars (exceeds 500 limit)
+	pasteContent := generateString(600)
+
+	// Create paste message
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// Extract toast message
+	toastMsg := extractToastMsg(cmd)
+
+	// Toast should be shown with correct truncation count
+	if toastMsg == nil {
+		t.Fatal("Expected toast for truncated paste, got none")
+	}
+	expectedToast := "100 chars truncated"
+	if toastMsg.Text != expectedToast {
+		t.Errorf("Expected toast message '%s', got: %s", expectedToast, toastMsg.Text)
+	}
+
+	// Content should be truncated to 500 chars
+	value := modal.textarea.Value()
+	if len([]rune(value)) != 500 {
+		t.Errorf("Expected textarea to contain 500 chars (truncated), got: %d", len([]rune(value)))
+	}
+
+	// Content should be first 500 chars of original
+	expectedContent := string([]rune(pasteContent)[:500])
+	if value != expectedContent {
+		t.Error("Truncated content doesn't match expected")
+	}
+}
+
+// TestNoteInputModal_PasteIntoPartiallyFilled_TruncatesCorrectly tests
+// that when textarea already has content, paste is truncated correctly.
+func TestNoteInputModal_PasteIntoPartiallyFilled_TruncatesCorrectly(t *testing.T) {
+	modal := NewNoteInputModal()
+	modal.Show()
+
+	// Set initial content to 400 chars (100 chars remaining space)
+	initialContent := generateString(400)
+	modal.textarea.SetValue(initialContent)
+
+	// Paste 300 chars - only 100 should fit, 200 truncated
+	pasteContent := generateString(300)
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// Extract toast message
+	toastMsg := extractToastMsg(cmd)
+
+	// Toast should show 200 chars truncated
+	if toastMsg == nil {
+		t.Fatal("Expected toast for truncated paste, got none")
+	}
+	expectedToast := "200 chars truncated"
+	if toastMsg.Text != expectedToast {
+		t.Errorf("Expected toast message '%s', got: %s", expectedToast, toastMsg.Text)
+	}
+
+	// Content should be at limit (500 chars total)
+	value := modal.textarea.Value()
+	runeCount := len([]rune(value))
+	if runeCount != 500 {
+		t.Errorf("Expected textarea to contain 500 chars total, got: %d", runeCount)
+	}
+}
+
+// TestNoteInputModal_PasteWhenFull_ShowsToastNoPaste tests that when
+// textarea is at the limit, paste shows toast but doesn't add content.
+func TestNoteInputModal_PasteWhenFull_ShowsToastNoPaste(t *testing.T) {
+	modal := NewNoteInputModal()
+	modal.Show()
+
+	// Fill textarea to exactly 500 chars
+	fullContent := generateString(500)
+	modal.textarea.SetValue(fullContent)
+
+	// Try to paste more content
+	pasteContent := "This should not be added"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// Extract toast message
+	toastMsg := extractToastMsg(cmd)
+
+	// Toast should show all chars truncated
+	if toastMsg == nil {
+		t.Fatal("Expected toast when pasting into full textarea, got none")
+	}
+	expectedToast := "24 chars truncated"
+	if toastMsg.Text != expectedToast {
+		t.Errorf("Expected toast message '%s', got: %s", expectedToast, toastMsg.Text)
+	}
+
+	// Content should still be exactly 500 chars
+	value := modal.textarea.Value()
+	if value != fullContent {
+		t.Error("Content should not have changed when pasting into full textarea")
+	}
+}
+
+// TestNoteInputModal_PasteWhenNotFocused_NoOp tests that paste is ignored
+// when the textarea is not focused.
+func TestNoteInputModal_PasteWhenNotFocused_NoOp(t *testing.T) {
+	modal := NewNoteInputModal()
+	modal.Show()
+
+	// Move focus to submit button (away from textarea)
+	modal.focus = focusSubmitButton
+
+	// Try to paste content
+	pasteContent := "This should not be added"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// No command should be returned
+	if cmd != nil {
+		t.Error("Expected no command when pasting with textarea not focused")
+	}
+
+	// Content should be empty
+	if modal.textarea.Value() != "" {
+		t.Error("Content should be empty when paste is ignored")
+	}
+}
+
+// TestNoteInputModal_PasteInvisibleModal_NoOp tests that paste is ignored
+// when the modal is not visible.
+func TestNoteInputModal_PasteInvisibleModal_NoOp(t *testing.T) {
+	modal := NewNoteInputModal()
+	// Modal is not shown (visible = false)
+
+	// Try to paste content
+	pasteContent := "This should not be added"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// No command should be returned
+	if cmd != nil {
+		t.Error("Expected no command when pasting into invisible modal")
+	}
+}
+
+// generateString generates a string of specified length using repeated pattern
+func generateString(length int) string {
+	pattern := "abcdefghijklmnopqrstuvwxyz0123456789"
+	result := make([]rune, length)
+	for i := 0; i < length; i++ {
+		result[i] = rune(pattern[i%len(pattern)])
+	}
+	return string(result)
+}

--- a/internal/tui/paste.go
+++ b/internal/tui/paste.go
@@ -1,0 +1,59 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ansiEscapePattern matches ANSI escape sequences including:
+// - Control sequences (ESC [ ...)
+// - Private sequences (ESC [ ? ...)
+// - Cursor control, color codes, etc.
+var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[a-zA-Z]`)
+
+// SanitizePaste cleans up pasted content by:
+// - Stripping ANSI escape sequences
+// - Removing null bytes and non-printable control chars (except \n, \t, \r)
+// - Normalizing CRLF (\r\n) to LF (\n)
+// - Trimming trailing whitespace
+func SanitizePaste(content string) string {
+	// Strip ANSI escape sequences
+	content = ansiEscapePattern.ReplaceAllString(content, "")
+
+	// Remove null bytes and non-printable control chars (keep \n, \t, \r)
+	var result strings.Builder
+	for _, r := range content {
+		switch {
+		case r == 0: // null byte
+			continue
+		case r >= 1 && r <= 8: // control chars (SOH through BS)
+			continue
+		case r == 11 || r == 12: // VT, FF
+			continue
+		case r >= 14 && r <= 31: // control chars (SO through US)
+			continue
+		case r == 127: // DEL
+			continue
+		default:
+			result.WriteRune(r)
+		}
+	}
+	content = result.String()
+
+	// Normalize CRLF to LF
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+
+	// Trim trailing whitespace from entire content and each line
+	content = strings.TrimRight(content, " \t\n\r")
+
+	return content
+}
+
+// newlinePattern matches one or more newline characters
+var newlinePattern = regexp.MustCompile(`\n+`)
+
+// collapseNewlines replaces all sequences of newlines with a single space.
+// This is used for single-line text inputs where newlines should be collapsed.
+func collapseNewlines(content string) string {
+	return newlinePattern.ReplaceAllString(content, " ")
+}

--- a/internal/tui/paste.go
+++ b/internal/tui/paste.go
@@ -43,7 +43,7 @@ func SanitizePaste(content string) string {
 	// Normalize CRLF to LF
 	content = strings.ReplaceAll(content, "\r\n", "\n")
 
-	// Trim trailing whitespace from entire content and each line
+	// Trim trailing whitespace from entire content
 	content = strings.TrimRight(content, " \t\n\r")
 
 	return content

--- a/internal/tui/paste_test.go
+++ b/internal/tui/paste_test.go
@@ -1,0 +1,265 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizePaste_StripsANSIEscapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "color codes",
+			input:    "\x1b[31mred text\x1b[0m",
+			expected: "red text",
+		},
+		{
+			name:     "bold formatting",
+			input:    "\x1b[1mbold\x1b[22m",
+			expected: "bold",
+		},
+		{
+			name:     "256 colors",
+			input:    "\x1b[38;5;196mred\x1b[0m",
+			expected: "red",
+		},
+		{
+			name:     "cursor control",
+			input:    "\x1b[2K\x1b[1Gclear line",
+			expected: "clear line",
+		},
+		{
+			name:     "multiple ANSI sequences",
+			input:    "\x1b[1m\x1b[31m\x1b[4mbold red underline\x1b[0m",
+			expected: "bold red underline",
+		},
+		{
+			name:     "no ANSI sequences",
+			input:    "plain text",
+			expected: "plain text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizePaste(tt.input)
+			if result != tt.expected {
+				t.Errorf("SanitizePaste(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizePaste_RemovesNullBytes(t *testing.T) {
+	input := "hello\x00world\x00"
+	expected := "helloworld"
+	result := SanitizePaste(input)
+	if result != expected {
+		t.Errorf("SanitizePaste(%q) = %q, want %q", input, result, expected)
+	}
+}
+
+func TestSanitizePaste_RemovesNonPrintableControlChars(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "SOH to BS (1-8)",
+			input:    "a\x01b\x02c\x03d\x04e\x05f\x06g\x07h\x08",
+			expected: "abcdefgh",
+		},
+		{
+			name:     "VT and FF (11-12)",
+			input:    "a\x0bb\x0c",
+			expected: "ab",
+		},
+		{
+			name:     "SO to US (14-31)",
+			input:    "a\x0eb\x0fc\x10d\x11e\x12f\x13g\x14h\x15i\x16j\x17k\x18l\x19m\x1an\x1bo\x1cp\x1dq\x1er\x1f",
+			expected: "abcdefghijklmnopqr",
+		},
+		{
+			name:     "DEL (127)",
+			input:    "a\x7fb",
+			expected: "ab",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizePaste(tt.input)
+			if result != tt.expected {
+				t.Errorf("SanitizePaste(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizePaste_PreservesValidWhitespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "preserves newlines",
+			input:    "line1\nline2\nline3",
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "preserves tabs",
+			input:    "col1\tcol2\tcol3",
+			expected: "col1\tcol2\tcol3",
+		},
+		{
+			name:     "preserves carriage returns (before normalization)",
+			input:    "line1\rline2",
+			expected: "line1\rline2",
+		},
+		{
+			name:     "preserves regular spaces",
+			input:    "hello world  test",
+			expected: "hello world  test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizePaste(tt.input)
+			if result != tt.expected {
+				t.Errorf("SanitizePaste(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizePaste_NormalizesCRLF(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "CRLF to LF",
+			input:    "line1\r\nline2\r\nline3",
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "mixed line endings",
+			input:    "line1\nline2\r\nline3\nline4",
+			expected: "line1\nline2\nline3\nline4",
+		},
+		{
+			name:     "only LF remains LF",
+			input:    "line1\nline2",
+			expected: "line1\nline2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizePaste(tt.input)
+			if result != tt.expected {
+				t.Errorf("SanitizePaste(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizePaste_TrimsTrailingWhitespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "trailing spaces",
+			input:    "hello world   ",
+			expected: "hello world",
+		},
+		{
+			name:     "trailing tabs",
+			input:    "hello world\t\t",
+			expected: "hello world",
+		},
+		{
+			name:     "trailing newlines",
+			input:    "hello world\n\n",
+			expected: "hello world",
+		},
+		{
+			name:     "trailing carriage returns",
+			input:    "hello world\r\r",
+			expected: "hello world",
+		},
+		{
+			name:     "mixed trailing whitespace",
+			input:    "hello world \t\n\r",
+			expected: "hello world",
+		},
+		{
+			name:     "no trailing whitespace",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "only trailing whitespace on last line",
+			input:    "line1\nline2   ",
+			expected: "line1\nline2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizePaste(tt.input)
+			if result != tt.expected {
+				t.Errorf("SanitizePaste(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizePaste_ComplexCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "ANSI + null + control + CRLF",
+			input:    "\x1b[31mhello\x00\r\n\x01world\x1b[0m\t\n",
+			expected: "hello\nworld",
+		},
+		{
+			name:     "terminal output with escapes",
+			input:    "\x1b[2K\x1b[1G\x1b[1;32m✓\x1b[0m Success\x00",
+			expected: "✓ Success",
+		},
+		{
+			name:     "large content with mixed issues",
+			input:    strings.Repeat("\x1b[31m\x00test\x01\r\n\x1b[0m", 100),
+			expected: strings.Repeat("test\n", 99) + "test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizePaste(tt.input)
+			if result != tt.expected {
+				t.Errorf("SanitizePaste(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizePaste_EmptyString(t *testing.T) {
+	result := SanitizePaste("")
+	if result != "" {
+		t.Errorf("SanitizePaste(\"\") = %q, want empty string", result)
+	}
+}

--- a/internal/tui/specwizard/description_step_paste_test.go
+++ b/internal/tui/specwizard/description_step_paste_test.go
@@ -1,0 +1,253 @@
+package specwizard
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/mark3labs/iteratr/internal/tui"
+)
+
+// generateLongString creates a string of exactly n 'a' characters
+func generateLongString(n int) string {
+	return strings.Repeat("a", n)
+}
+
+func TestDescriptionStep_PasteWithinLimit_NoTruncation(t *testing.T) {
+	step := NewDescriptionStep()
+
+	// Paste 100 chars into empty textarea (limit is 5000)
+	pasteContent := generateLongString(100)
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	cmd := step.Update(pasteMsg)
+
+	// Command should be from textarea (cursor blink), not a batch with toast
+	// We can't easily check the exact command type, but we can verify
+	// that executing it doesn't produce a toast message
+	if cmd != nil {
+		msg := cmd()
+		// Should NOT be a toast message
+		if _, ok := msg.(tui.ShowToastMsg); ok {
+			t.Error("Did not expect ShowToastMsg for within-limit paste")
+		}
+	}
+
+	// Verify content was added
+	if step.textarea.Value() != pasteContent {
+		t.Errorf("Expected textarea value to be %q, got %q", pasteContent, step.textarea.Value())
+	}
+}
+
+func TestDescriptionStep_PasteExceedsLimit_Truncates(t *testing.T) {
+	step := NewDescriptionStep()
+
+	// Paste 6000 chars (exceeds 5000 limit)
+	pasteContent := generateLongString(6000)
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	cmd := step.Update(pasteMsg)
+
+	// Should get a batch command with textarea update + toast
+	if cmd == nil {
+		t.Fatal("Expected batch command for truncation, got nil")
+	}
+
+	// Execute the command and check for toast message
+	msg := cmd()
+	batchMsgs, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Expected tea.BatchMsg, got %T", msg)
+	}
+
+	// Should have 2 commands: textarea update + toast
+	if len(batchMsgs) != 2 {
+		t.Errorf("Expected 2 commands in batch, got %d", len(batchMsgs))
+	}
+
+	// Check for toast message with "1000 chars truncated" (6000 - 5000)
+	foundToast := false
+	for _, batchCmd := range batchMsgs {
+		if batchCmd == nil {
+			continue
+		}
+		batchMsg := batchCmd()
+		if toastMsg, ok := batchMsg.(tui.ShowToastMsg); ok {
+			if toastMsg.Text != "1000 chars truncated" {
+				t.Errorf("Expected toast '1000 chars truncated', got %q", toastMsg.Text)
+			}
+			foundToast = true
+		}
+	}
+	if !foundToast {
+		t.Error("Expected ShowToastMsg in batch, not found")
+	}
+
+	// Verify content was truncated to 5000 chars
+	if len([]rune(step.textarea.Value())) != 5000 {
+		t.Errorf("Expected textarea value to be 5000 chars, got %d", len([]rune(step.textarea.Value())))
+	}
+}
+
+func TestDescriptionStep_PasteIntoPartiallyFilled_TruncatesCorrectly(t *testing.T) {
+	step := NewDescriptionStep()
+
+	// First, add 4000 chars
+	step.textarea.SetValue(generateLongString(4000))
+
+	// Now paste 2000 more (would exceed 5000)
+	pasteContent := generateLongString(2000)
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	cmd := step.Update(pasteMsg)
+
+	// Should get batch command for truncation
+	if cmd == nil {
+		t.Fatal("Expected batch command for truncation, got nil")
+	}
+
+	msg := cmd()
+	_, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Expected tea.BatchMsg, got %T", msg)
+	}
+
+	// Check for toast message with "1000 chars truncated" (4000 + 2000 - 5000)
+	foundToast := false
+	if batchMsg, ok := msg.(tea.BatchMsg); ok {
+		for _, batchCmd := range batchMsg {
+			if batchCmd == nil {
+				continue
+			}
+			if toastMsg, ok := batchCmd().(tui.ShowToastMsg); ok {
+				if toastMsg.Text != "1000 chars truncated" {
+					t.Errorf("Expected toast '1000 chars truncated', got %q", toastMsg.Text)
+				}
+				foundToast = true
+			}
+		}
+	}
+	if !foundToast {
+		t.Error("Expected ShowToastMsg in batch, not found")
+	}
+
+	// Verify content is 5000 chars (4000 + 1000)
+	if len([]rune(step.textarea.Value())) != 5000 {
+		t.Errorf("Expected textarea value to be 5000 chars, got %d", len([]rune(step.textarea.Value())))
+	}
+}
+
+func TestDescriptionStep_PasteWhenFull_ShowsToastOnly(t *testing.T) {
+	step := NewDescriptionStep()
+
+	// Fill textarea completely
+	step.textarea.SetValue(generateLongString(5000))
+
+	// Try to paste more content
+	pasteContent := generateLongString(100)
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	cmd := step.Update(pasteMsg)
+
+	// Should get a command (the toast)
+	if cmd == nil {
+		t.Fatal("Expected command for toast, got nil")
+	}
+
+	msg := cmd()
+	toastMsg, ok := msg.(tui.ShowToastMsg)
+	if !ok {
+		t.Fatalf("Expected ShowToastMsg, got %T", msg)
+	}
+
+	if toastMsg.Text != "100 chars truncated" {
+		t.Errorf("Expected toast '100 chars truncated', got %q", toastMsg.Text)
+	}
+
+	// Verify content unchanged
+	if len([]rune(step.textarea.Value())) != 5000 {
+		t.Errorf("Expected textarea value to remain 5000 chars, got %d", len([]rune(step.textarea.Value())))
+	}
+}
+
+func TestDescriptionStep_PasteSanitizesContent(t *testing.T) {
+	step := NewDescriptionStep()
+
+	// Paste content with ANSI codes and null bytes
+	pasteContent := "Hello \x1b[31mRed\x1b[0m World\x00!"
+	expectedContent := "Hello Red World!"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	cmd := step.Update(pasteMsg)
+
+	// Command should be from textarea (cursor blink), not a batch with toast
+	// We can verify by checking that executing it doesn't produce a toast
+	if cmd != nil {
+		msg := cmd()
+		// Check that it's not a toast (no truncation needed for short content)
+		if _, ok := msg.(tui.ShowToastMsg); ok {
+			t.Error("Did not expect toast for short paste")
+		}
+	}
+
+	// Verify content was sanitized (ANSI codes and null bytes removed)
+	if step.textarea.Value() != expectedContent {
+		t.Errorf("Expected sanitized content %q, got %q", expectedContent, step.textarea.Value())
+	}
+}
+
+func TestDescriptionStep_PasteWithNewlines_Preserved(t *testing.T) {
+	step := NewDescriptionStep()
+
+	// Multi-line paste (should be preserved for textarea)
+	pasteContent := "Line 1\nLine 2\nLine 3"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	cmd := step.Update(pasteMsg)
+
+	// Command should be from textarea (cursor blink), not a batch with toast
+	// We can verify by checking that executing it doesn't produce a toast
+	if cmd != nil {
+		msg := cmd()
+		if _, ok := msg.(tui.ShowToastMsg); ok {
+			t.Error("Did not expect toast for short paste")
+		}
+	}
+
+	// Verify newlines are preserved (textarea allows newlines)
+	if step.textarea.Value() != pasteContent {
+		t.Errorf("Expected content with newlines preserved %q, got %q", pasteContent, step.textarea.Value())
+	}
+}
+
+func TestDescriptionStep_PasteCRLF_Normalized(t *testing.T) {
+	step := NewDescriptionStep()
+
+	// Paste with Windows-style line endings
+	pasteContent := "Line 1\r\nLine 2\r\nLine 3"
+	expectedContent := "Line 1\nLine 2\nLine 3" // Should be normalized to LF
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	step.Update(pasteMsg)
+
+	// Verify CRLF is normalized to LF
+	if step.textarea.Value() != expectedContent {
+		t.Errorf("Expected CRLF normalized to LF %q, got %q", expectedContent, step.textarea.Value())
+	}
+}
+
+func TestDescriptionStep_PasteTrailingWhitespace_Trimmed(t *testing.T) {
+	step := NewDescriptionStep()
+
+	// Paste with trailing whitespace
+	pasteContent := "Hello World   \t\n"
+	expectedContent := "Hello World" // Trailing whitespace trimmed
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	step.Update(pasteMsg)
+
+	// Verify trailing whitespace is trimmed
+	if step.textarea.Value() != expectedContent {
+		t.Errorf("Expected trailing whitespace trimmed to %q, got %q", expectedContent, step.textarea.Value())
+	}
+}

--- a/internal/tui/specwizard/title_step_paste_test.go
+++ b/internal/tui/specwizard/title_step_paste_test.go
@@ -1,0 +1,232 @@
+package specwizard
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/mark3labs/iteratr/internal/tui"
+)
+
+func TestTitleStep_Paste_CollapsesNewlines(t *testing.T) {
+	step := NewTitleStep()
+
+	// Paste multi-line content
+	pasteContent := "line1\nline2\nline3"
+	msg := tea.PasteMsg{Content: pasteContent}
+
+	cmd := step.Update(msg)
+	_ = cmd // Command may be non-nil (e.g., for cursor blink)
+
+	// Check that content was pasted and newlines were collapsed to spaces
+	value := step.GetTitle()
+	if value != "line1 line2 line3" {
+		t.Errorf("Expected 'line1 line2 line3', got '%s'", value)
+	}
+}
+
+func TestTitleStep_Paste_CollapsesCarriageReturns(t *testing.T) {
+	step := NewTitleStep()
+
+	// Paste content with CRLF line endings
+	pasteContent := "line1\r\nline2\r\nline3"
+	msg := tea.PasteMsg{Content: pasteContent}
+
+	step.Update(msg)
+
+	// Check that CRLF was collapsed to spaces
+	value := step.GetTitle()
+	if value != "line1 line2 line3" {
+		t.Errorf("Expected 'line1 line2 line3', got '%s'", value)
+	}
+}
+
+func TestTitleStep_Paste_SanitizesAndCollapses(t *testing.T) {
+	step := NewTitleStep()
+
+	// Paste content with ANSI codes and newlines
+	pasteContent := "\x1b[31mred\x1b[0m\nline2\n\x00nullbyte"
+	msg := tea.PasteMsg{Content: pasteContent}
+
+	step.Update(msg)
+
+	// Check that ANSI codes and null bytes are removed, newlines collapsed
+	value := step.GetTitle()
+	expected := "red line2 nullbyte"
+	if value != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, value)
+	}
+}
+
+func TestTitleStep_Paste_CollapsesConsecutiveWhitespace(t *testing.T) {
+	step := NewTitleStep()
+
+	// Paste content with multiple consecutive newlines and spaces
+	pasteContent := "line1\n\n\n  line2   \n\nline3"
+	msg := tea.PasteMsg{Content: pasteContent}
+
+	step.Update(msg)
+
+	// Check that all consecutive whitespace is collapsed to single spaces
+	value := step.GetTitle()
+	expected := "line1 line2 line3"
+	if value != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, value)
+	}
+}
+
+func TestTitleStep_Paste_EmptyContent(t *testing.T) {
+	step := NewTitleStep()
+
+	// Paste empty content
+	msg := tea.PasteMsg{Content: ""}
+
+	step.Update(msg)
+
+	// Check that nothing was pasted
+	value := step.GetTitle()
+	if value != "" {
+		t.Errorf("Expected empty string, got '%s'", value)
+	}
+}
+
+func TestTitleStep_Paste_RespectsCharLimit(t *testing.T) {
+	step := NewTitleStep()
+
+	// Create content that exceeds the 100 char limit
+	pasteContent := strings.Repeat("a", 150)
+	msg := tea.PasteMsg{Content: pasteContent}
+
+	step.Update(msg)
+
+	// Check that textinput enforces its CharLimit of 100
+	value := step.input.Value()
+	if len(value) > 100 {
+		t.Errorf("Expected length <= 100, got %d", len(value))
+	}
+}
+
+func TestCollapseNewlines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single newline",
+			input:    "line1\nline2",
+			expected: "line1 line2",
+		},
+		{
+			name:     "multiple newlines",
+			input:    "line1\nline2\nline3",
+			expected: "line1 line2 line3",
+		},
+		{
+			name:     "CRLF line endings",
+			input:    "line1\r\nline2\r\nline3",
+			expected: "line1 line2 line3",
+		},
+		{
+			name:     "mixed line endings",
+			input:    "line1\nline2\r\nline3\rline4",
+			expected: "line1 line2 line3 line4",
+		},
+		{
+			name:     "consecutive newlines",
+			input:    "line1\n\n\nline2",
+			expected: "line1 line2",
+		},
+		{
+			name:     "consecutive spaces and newlines",
+			input:    "line1   \n\n  line2",
+			expected: "line1 line2",
+		},
+		{
+			name:     "single line no change",
+			input:    "single line text",
+			expected: "single line text",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only whitespace",
+			input:    "   \n\t\r   ",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := collapseNewlines(tt.input)
+			if result != tt.expected {
+				t.Errorf("collapseNewlines(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTitleStep_Paste_ClearsError(t *testing.T) {
+	step := NewTitleStep()
+
+	// First trigger an error by submitting empty title
+	step.Submit()
+
+	if step.err == "" {
+		t.Error("Expected error to be set")
+	}
+
+	// Now paste some content
+	msg := tea.PasteMsg{Content: "valid title"}
+	step.Update(msg)
+
+	// Error should be cleared
+	if step.err != "" {
+		t.Errorf("Expected error to be cleared, got: %s", step.err)
+	}
+}
+
+func TestTitleStep_Paste_NoErrorWhenValid(t *testing.T) {
+	step := NewTitleStep()
+
+	// Paste valid content when there's no error
+	msg := tea.PasteMsg{Content: "some title"}
+	step.Update(msg)
+
+	// Error should remain empty
+	if step.err != "" {
+		t.Errorf("Expected no error, got: %s", step.err)
+	}
+}
+
+func TestTitleStep_SanitizePasteIntegration(t *testing.T) {
+	// Test that SanitizePaste from tui package works correctly with TitleStep
+	input := "text\x1b[31m with ANSI\x1b[0m and\x00null\nnewlines"
+	sanitized := tui.SanitizePaste(input)
+
+	// ANSI codes and null bytes should be removed, newlines preserved at this stage
+	if strings.Contains(sanitized, "\x1b") {
+		t.Error("SanitizePaste should remove ANSI escape codes")
+	}
+	if strings.Contains(sanitized, "\x00") {
+		t.Error("SanitizePaste should remove null bytes")
+	}
+	if !strings.Contains(sanitized, "\n") {
+		t.Error("SanitizePaste should preserve newlines for collapseNewlines to handle")
+	}
+
+	// Now test through TitleStep
+	step := NewTitleStep()
+	msg := tea.PasteMsg{Content: input}
+	step.Update(msg)
+
+	value := step.GetTitle()
+	// Note: null byte is removed without replacement, so "and" and "null" become "andnull"
+	expected := "text with ANSI andnull newlines"
+	if value != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, value)
+	}
+}

--- a/internal/tui/task_input_modal_paste_test.go
+++ b/internal/tui/task_input_modal_paste_test.go
@@ -1,0 +1,224 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestTaskInputModal_PasteWithinLimit_NoTruncation tests that paste content
+// within the char limit is forwarded without modification.
+func TestTaskInputModal_PasteWithinLimit_NoTruncation(t *testing.T) {
+	modal := NewTaskInputModal()
+	modal.Show()
+
+	// Initial content is empty (0 chars)
+	// Paste 100 chars - should fit within 500 limit
+	pasteContent := "This is a test task content that is well within the character limit of 500 characters."
+
+	// Create paste message
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// Execute command to get any messages
+	toastMsg := extractToastMsg(cmd)
+
+	// No toast should be shown (no truncation)
+	if toastMsg != nil {
+		t.Errorf("Expected no toast for paste within limit, got: %s", toastMsg.Text)
+	}
+
+	// Content should be inserted
+	if modal.textarea.Value() != pasteContent {
+		t.Errorf("Expected textarea to contain pasted content, got: %s", modal.textarea.Value())
+	}
+}
+
+// TestTaskInputModal_PasteExceedsLimit_Truncates tests that paste content
+// exceeding the char limit is truncated and a toast is shown.
+func TestTaskInputModal_PasteExceedsLimit_Truncates(t *testing.T) {
+	modal := NewTaskInputModal()
+	modal.Show()
+
+	// Initial content is empty (0 chars)
+	// Create paste content of 600 chars (exceeds 500 limit)
+	pasteContent := generateString(600)
+
+	// Create paste message
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// Extract toast message
+	toastMsg := extractToastMsg(cmd)
+
+	// Toast should be shown with correct truncation count
+	if toastMsg == nil {
+		t.Fatal("Expected toast for truncated paste, got none")
+	}
+	expectedToast := "100 chars truncated"
+	if toastMsg.Text != expectedToast {
+		t.Errorf("Expected toast message '%s', got: %s", expectedToast, toastMsg.Text)
+	}
+
+	// Content should be truncated to 500 chars
+	value := modal.textarea.Value()
+	if len([]rune(value)) != 500 {
+		t.Errorf("Expected textarea to contain 500 chars (truncated), got: %d", len([]rune(value)))
+	}
+
+	// Content should be first 500 chars of original
+	expectedContent := string([]rune(pasteContent)[:500])
+	if value != expectedContent {
+		t.Error("Truncated content doesn't match expected")
+	}
+}
+
+// TestTaskInputModal_PasteIntoPartiallyFilled_TruncatesCorrectly tests
+// that when textarea already has content, paste is truncated correctly.
+func TestTaskInputModal_PasteIntoPartiallyFilled_TruncatesCorrectly(t *testing.T) {
+	modal := NewTaskInputModal()
+	modal.Show()
+
+	// Set initial content to 400 chars (100 chars remaining space)
+	initialContent := generateString(400)
+	modal.textarea.SetValue(initialContent)
+
+	// Paste 300 chars - only 100 should fit, 200 truncated
+	pasteContent := generateString(300)
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// Extract toast message
+	toastMsg := extractToastMsg(cmd)
+
+	// Toast should show 200 chars truncated
+	if toastMsg == nil {
+		t.Fatal("Expected toast for truncated paste, got none")
+	}
+	expectedToast := "200 chars truncated"
+	if toastMsg.Text != expectedToast {
+		t.Errorf("Expected toast message '%s', got: %s", expectedToast, toastMsg.Text)
+	}
+
+	// Content should be at limit (500 chars total)
+	value := modal.textarea.Value()
+	runeCount := len([]rune(value))
+	if runeCount != 500 {
+		t.Errorf("Expected textarea to contain 500 chars total, got: %d", runeCount)
+	}
+}
+
+// TestTaskInputModal_PasteWhenFull_ShowsToastNoPaste tests that when
+// textarea is at the limit, paste shows toast but doesn't add content.
+func TestTaskInputModal_PasteWhenFull_ShowsToastNoPaste(t *testing.T) {
+	modal := NewTaskInputModal()
+	modal.Show()
+
+	// Fill textarea to exactly 500 chars
+	fullContent := generateString(500)
+	modal.textarea.SetValue(fullContent)
+
+	// Try to paste more content
+	pasteContent := "This should not be added"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// Extract toast message
+	toastMsg := extractToastMsg(cmd)
+
+	// Toast should show all chars truncated
+	if toastMsg == nil {
+		t.Fatal("Expected toast when pasting into full textarea, got none")
+	}
+	expectedToast := "24 chars truncated"
+	if toastMsg.Text != expectedToast {
+		t.Errorf("Expected toast message '%s', got: %s", expectedToast, toastMsg.Text)
+	}
+
+	// Content should still be exactly 500 chars
+	value := modal.textarea.Value()
+	if value != fullContent {
+		t.Error("Content should not have changed when pasting into full textarea")
+	}
+}
+
+// TestTaskInputModal_PasteWhenNotFocused_NoOp tests that paste is ignored
+// when the textarea is not focused.
+func TestTaskInputModal_PasteWhenNotFocused_NoOp(t *testing.T) {
+	modal := NewTaskInputModal()
+	modal.Show()
+
+	// Move focus to submit button (away from textarea)
+	modal.focus = focusSubmitButton
+
+	// Try to paste content
+	pasteContent := "This should not be added"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// No command should be returned
+	if cmd != nil {
+		t.Error("Expected no command when pasting with textarea not focused")
+	}
+
+	// Content should be empty
+	if modal.textarea.Value() != "" {
+		t.Error("Content should be empty when paste is ignored")
+	}
+}
+
+// TestTaskInputModal_PasteInvisibleModal_NoOp tests that paste is ignored
+// when the modal is not visible.
+func TestTaskInputModal_PasteInvisibleModal_NoOp(t *testing.T) {
+	modal := NewTaskInputModal()
+	// Modal is not shown (visible = false)
+
+	// Try to paste content
+	pasteContent := "This should not be added"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// No command should be returned
+	if cmd != nil {
+		t.Error("Expected no command when pasting into invisible modal")
+	}
+}
+
+// TestTaskInputModal_PastePrioritySelectorFocused_NoOp tests that paste is ignored
+// when the priority selector is focused.
+func TestTaskInputModal_PastePrioritySelectorFocused_NoOp(t *testing.T) {
+	modal := NewTaskInputModal()
+	modal.Show()
+
+	// Move focus to priority selector (away from textarea)
+	modal.focus = focusPrioritySelector
+
+	// Try to paste content
+	pasteContent := "This should not be added"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	// Handle the paste
+	cmd := modal.Update(pasteMsg)
+
+	// No command should be returned
+	if cmd != nil {
+		t.Error("Expected no command when pasting with priority selector focused")
+	}
+
+	// Content should be empty
+	if modal.textarea.Value() != "" {
+		t.Error("Content should be empty when paste is ignored")
+	}
+}

--- a/internal/tui/toast.go
+++ b/internal/tui/toast.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/mark3labs/iteratr/internal/tui/theme"
+)
+
+// ToastDismissMsg is sent when the toast should be dismissed.
+type ToastDismissMsg struct{}
+
+// ShowToastMsg is sent to show a toast notification.
+type ShowToastMsg struct {
+	Text string
+}
+
+// Toast is a minimal toast notification component.
+// Shows a message in the bottom-right corner that auto-dismisses after 3 seconds.
+type Toast struct {
+	message   string
+	visible   bool
+	dismissAt time.Time
+}
+
+// NewToast creates a new Toast component.
+func NewToast() *Toast {
+	return &Toast{}
+}
+
+// Show displays a toast with the given message.
+// The toast will auto-dismiss after 3 seconds.
+func (t *Toast) Show(msg string) tea.Cmd {
+	t.message = msg
+	t.visible = true
+	t.dismissAt = time.Now().Add(3 * time.Second)
+	return t.dismissCmd()
+}
+
+// dismissCmd returns a command that will dismiss the toast after the remaining time.
+func (t *Toast) dismissCmd() tea.Cmd {
+	remaining := time.Until(t.dismissAt)
+	if remaining <= 0 {
+		remaining = 1 * time.Millisecond
+	}
+	return tea.Tick(remaining, func(time.Time) tea.Msg {
+		return ToastDismissMsg{}
+	})
+}
+
+// Update handles messages for the toast component.
+// Returns a command to re-schedule dismissal if needed.
+func (t *Toast) Update(msg tea.Msg) tea.Cmd {
+	switch msg.(type) {
+	case ToastDismissMsg:
+		t.visible = false
+		t.message = ""
+		return nil
+	}
+	return nil
+}
+
+// View renders the toast at the given screen dimensions.
+// Returns empty string if toast is not visible.
+// Positions the toast in the bottom-right corner, above the status bar.
+func (t *Toast) View(width, height int) string {
+	if !t.visible || t.message == "" {
+		return ""
+	}
+
+	th := theme.Current()
+
+	// Style the toast with warning colors (yellow) to indicate notification
+	style := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(th.FgBase)).
+		Background(lipgloss.Color(th.Warning)).
+		Padding(0, 1).
+		Bold(true)
+
+	content := style.Render(t.message)
+
+	// Calculate position: bottom-right with 1 cell padding from edges
+	// The toast appears above the status bar, so we position at height-2
+	contentWidth := lipgloss.Width(content)
+	if contentWidth > width-2 {
+		content = style.Width(width - 2).Render(t.message)
+	}
+
+	// Position at row height-2 (1 row above status bar)
+	verticalPadding := height - 2
+	if verticalPadding < 0 {
+		verticalPadding = 0
+	}
+
+	// Build the positioned toast with bottom-right alignment
+	var result string
+	for i := 0; i < verticalPadding; i++ {
+		result += "\n"
+	}
+	result += lipgloss.NewStyle().
+		Width(width).
+		Align(lipgloss.Right).
+		PaddingRight(1).
+		Render(content)
+
+	return result
+}
+
+// IsVisible returns whether the toast is currently visible.
+func (t *Toast) IsVisible() bool {
+	return t.visible
+}
+
+// GetMessage returns the current toast message (empty if not visible).
+func (t *Toast) GetMessage() string {
+	if !t.visible {
+		return ""
+	}
+	return t.message
+}

--- a/internal/tui/toast_test.go
+++ b/internal/tui/toast_test.go
@@ -1,0 +1,248 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestToast_ShowDisplaysMessage(t *testing.T) {
+	toast := NewToast()
+
+	cmd := toast.Show("test message")
+
+	if !toast.IsVisible() {
+		t.Error("expected toast to be visible after Show()")
+	}
+
+	if toast.GetMessage() != "test message" {
+		t.Errorf("expected message 'test message', got %q", toast.GetMessage())
+	}
+
+	// Verify command is returned (for dismissal)
+	if cmd == nil {
+		t.Error("expected Show() to return a command for dismissal")
+	}
+}
+
+func TestToast_ViewReturnsEmptyWhenNotVisible(t *testing.T) {
+	toast := NewToast()
+
+	view := toast.View(80, 24)
+
+	if view != "" {
+		t.Errorf("expected empty view when not visible, got %q", view)
+	}
+}
+
+func TestToast_ViewRendersMessageWhenVisible(t *testing.T) {
+	toast := NewToast()
+	toast.Show("142 chars truncated")
+
+	view := toast.View(80, 24)
+
+	if view == "" {
+		t.Error("expected non-empty view when visible")
+	}
+
+	// The view should contain the message
+	if !strings.Contains(view, "142 chars truncated") {
+		t.Errorf("expected view to contain message, got %q", view)
+	}
+}
+
+func TestToast_DismissMsgHidesToast(t *testing.T) {
+	toast := NewToast()
+	toast.Show("test message")
+
+	// Send dismiss message
+	cmd := toast.Update(ToastDismissMsg{})
+
+	if toast.IsVisible() {
+		t.Error("expected toast to be hidden after ToastDismissMsg")
+	}
+
+	if toast.GetMessage() != "" {
+		t.Error("expected message to be cleared after dismiss")
+	}
+
+	if cmd != nil {
+		t.Error("expected no command after dismiss")
+	}
+}
+
+func TestToast_ShowClearsPreviousMessage(t *testing.T) {
+	toast := NewToast()
+	toast.Show("first message")
+	toast.Show("second message")
+
+	if toast.GetMessage() != "second message" {
+		t.Errorf("expected 'second message', got %q", toast.GetMessage())
+	}
+}
+
+func TestToast_ShowUpdatesDismissTime(t *testing.T) {
+	toast := NewToast()
+
+	// Show first message
+	toast.Show("first")
+	firstDismissAt := toast.dismissAt
+
+	// Wait a tiny bit
+	time.Sleep(10 * time.Millisecond)
+
+	// Show second message - should reset dismiss time
+	toast.Show("second")
+	secondDismissAt := toast.dismissAt
+
+	if !secondDismissAt.After(firstDismissAt) {
+		t.Error("expected second dismiss time to be after first")
+	}
+}
+
+func TestToast_ViewPositionsBottomRight(t *testing.T) {
+	toast := NewToast()
+	toast.Show("test")
+
+	view := toast.View(80, 24)
+	lines := strings.Split(view, "\n")
+
+	// Should have vertical positioning (newlines at start)
+	if len(lines) < 2 {
+		t.Errorf("expected multiple lines for positioning, got %d", len(lines))
+	}
+
+	// The last line should contain the toast content
+	lastLine := lines[len(lines)-1]
+	if !strings.Contains(lastLine, "test") {
+		t.Errorf("expected toast content in last line, got %q", lastLine)
+	}
+}
+
+func TestToast_ViewHandlesNarrowWidth(t *testing.T) {
+	toast := NewToast()
+	toast.Show("very long message that might exceed narrow width")
+
+	// Test with very narrow width
+	view := toast.View(10, 24)
+
+	// Should still render something
+	if view == "" {
+		t.Error("expected view even with narrow width")
+	}
+}
+
+func TestToast_ViewHandlesZeroDimensions(t *testing.T) {
+	toast := NewToast()
+	toast.Show("test")
+
+	view := toast.View(0, 0)
+
+	// Should handle gracefully
+	if view == "" {
+		// This is acceptable for zero dimensions
+		t.Log("view is empty for zero dimensions (acceptable)")
+	}
+}
+
+func TestToast_DismissCmdCalculatesRemainingTime(t *testing.T) {
+	toast := NewToast()
+	toast.Show("test")
+
+	// Get the dismiss command
+	cmd := toast.dismissCmd()
+
+	if cmd == nil {
+		t.Error("expected non-nil dismiss command")
+	}
+
+	// Execute the command to verify it returns a message
+	msg := cmd()
+
+	// Should return a ToastDismissMsg
+	if _, ok := msg.(ToastDismissMsg); !ok {
+		t.Errorf("expected ToastDismissMsg, got %T", msg)
+	}
+}
+
+func TestToast_UpdateIgnoresOtherMessages(t *testing.T) {
+	toast := NewToast()
+	toast.Show("test")
+
+	// Send unrelated message
+	cmd := toast.Update(tea.KeyPressMsg{})
+
+	// Toast should still be visible
+	if !toast.IsVisible() {
+		t.Error("expected toast to remain visible after unrelated message")
+	}
+
+	if cmd != nil {
+		t.Error("expected no command for unrelated message")
+	}
+}
+
+func TestToast_ShowToastMsgType(t *testing.T) {
+	// Verify the message type exists and has the expected structure
+	msg := ShowToastMsg{Text: "test notification"}
+
+	if msg.Text != "test notification" {
+		t.Errorf("expected text 'test notification', got %q", msg.Text)
+	}
+}
+
+func TestToast_MultipleShowCalls(t *testing.T) {
+	toast := NewToast()
+
+	// Show multiple messages in sequence
+	messages := []string{
+		"first notification",
+		"second notification",
+		"third notification",
+	}
+
+	for _, msg := range messages {
+		toast.Show(msg)
+
+		if toast.GetMessage() != msg {
+			t.Errorf("expected message %q, got %q", msg, toast.GetMessage())
+		}
+
+		if !toast.IsVisible() {
+			t.Error("expected toast to be visible")
+		}
+	}
+}
+
+func TestToast_DismissSequence(t *testing.T) {
+	toast := NewToast()
+
+	// Show toast
+	cmd := toast.Show("test")
+	if cmd == nil {
+		t.Fatal("expected Show() to return dismiss command")
+	}
+
+	// Execute the command to get the dismiss message
+	msg := cmd()
+	dismissMsg, ok := msg.(ToastDismissMsg)
+	if !ok {
+		t.Fatalf("expected ToastDismissMsg from command, got %T", msg)
+	}
+
+	// Send the dismiss message to the toast
+	toast.Update(dismissMsg)
+
+	// Toast should now be hidden
+	if toast.IsVisible() {
+		t.Error("expected toast to be hidden after complete dismiss sequence")
+	}
+
+	// View should be empty
+	view := toast.View(80, 24)
+	if view != "" {
+		t.Errorf("expected empty view after dismiss, got %q", view)
+	}
+}

--- a/internal/tui/wizard/model_selector_paste_test.go
+++ b/internal/tui/wizard/model_selector_paste_test.go
@@ -1,0 +1,150 @@
+package wizard
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestModelSelectorStep_Paste_CollapsesNewlines tests that multi-line paste
+// content has newlines collapsed to spaces in the search input.
+func TestModelSelectorStep_Paste_CollapsesNewlines(t *testing.T) {
+	step := NewModelSelectorStep()
+	step.loading = false     // Ensure not in loading state
+	step.searchInput.Focus() // Focus the search input
+
+	// Paste multi-line text
+	pasteContent := "line1\nline2\n\nline3"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	step.Update(pasteMsg)
+
+	// Verify newlines were collapsed to single space
+	expected := "line1 line2 line3"
+	if step.searchInput.Value() != expected {
+		t.Errorf("Expected search input to contain '%s', got: '%s'", expected, step.searchInput.Value())
+	}
+}
+
+// TestModelSelectorStep_Paste_SanitizesContent tests that pasted content
+// is sanitized (ANSI codes, null bytes removed).
+func TestModelSelectorStep_Paste_SanitizesContent(t *testing.T) {
+	step := NewModelSelectorStep()
+	step.loading = false
+	step.searchInput.Focus() // Focus the search input
+
+	// Paste content with ANSI codes and null bytes
+	pasteContent := "\x1b[31mred\x1b[0m text\x00"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	step.Update(pasteMsg)
+
+	// Verify ANSI codes and null bytes were removed
+	expected := "red text"
+	if step.searchInput.Value() != expected {
+		t.Errorf("Expected search input to contain '%s', got: '%s'", expected, step.searchInput.Value())
+	}
+}
+
+// TestModelSelectorStep_Paste_CombinedSanitizationAndNewlineCollapse tests
+// that all transformations work together: ANSI stripped, newlines collapsed.
+func TestModelSelectorStep_Paste_CombinedSanitizationAndNewlineCollapse(t *testing.T) {
+	step := NewModelSelectorStep()
+	step.loading = false
+	step.searchInput.Focus() // Focus the search input
+
+	// Paste content with newlines, ANSI codes, and CRLF
+	pasteContent := "\x1b[1mbold\x1b[0m\r\nline1\n\nline2\x00"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	step.Update(pasteMsg)
+
+	// Verify all transformations
+	expected := "bold line1 line2"
+	if step.searchInput.Value() != expected {
+		t.Errorf("Expected search input to contain '%s', got: '%s'", expected, step.searchInput.Value())
+	}
+}
+
+// TestModelSelectorStep_Paste_WhenLoading_NoOp tests that paste is ignored
+// when the step is in loading state.
+func TestModelSelectorStep_Paste_WhenLoading_NoOp(t *testing.T) {
+	step := NewModelSelectorStep()
+	step.loading = true
+
+	// Try to paste while loading
+	pasteContent := "test content"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	cmd := step.Update(pasteMsg)
+
+	// No command should be returned
+	if cmd != nil {
+		t.Error("Expected no command when pasting during loading state")
+	}
+
+	// Search input should be empty
+	if step.searchInput.Value() != "" {
+		t.Errorf("Expected search input to be empty, got: '%s'", step.searchInput.Value())
+	}
+}
+
+// TestModelSelectorStep_Paste_WhenError_NoOp tests that paste is ignored
+// when the step is in error state.
+func TestModelSelectorStep_Paste_WhenError_NoOp(t *testing.T) {
+	step := NewModelSelectorStep()
+	step.loading = false
+	step.error = "some error"
+
+	// Try to paste while in error state
+	pasteContent := "test content"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	cmd := step.Update(pasteMsg)
+
+	// No command should be returned
+	if cmd != nil {
+		t.Error("Expected no command when pasting during error state")
+	}
+
+	// Search input should be empty
+	if step.searchInput.Value() != "" {
+		t.Errorf("Expected search input to be empty, got: '%s'", step.searchInput.Value())
+	}
+}
+
+// TestModelSelectorStep_Paste_SingleLine_NoChange tests that single-line
+// paste content without newlines is inserted unchanged (except sanitization).
+func TestModelSelectorStep_Paste_SingleLine_NoChange(t *testing.T) {
+	step := NewModelSelectorStep()
+	step.loading = false
+	step.searchInput.Focus() // Focus the search input
+
+	// Paste single-line content
+	pasteContent := "single line content"
+	pasteMsg := tea.PasteMsg{Content: pasteContent}
+
+	step.Update(pasteMsg)
+
+	// Content should be inserted as-is
+	if step.searchInput.Value() != pasteContent {
+		t.Errorf("Expected search input to contain '%s', got: '%s'", pasteContent, step.searchInput.Value())
+	}
+}
+
+// TestModelSelectorStep_Paste_EmptyContent tests that empty paste content
+// is handled gracefully.
+func TestModelSelectorStep_Paste_EmptyContent(t *testing.T) {
+	step := NewModelSelectorStep()
+	step.loading = false
+
+	// Paste empty content
+	pasteMsg := tea.PasteMsg{Content: ""}
+
+	step.Update(pasteMsg)
+
+	// Search input should remain empty
+	if step.searchInput.Value() != "" {
+		t.Errorf("Expected search input to be empty, got: '%s'", step.searchInput.Value())
+	}
+}

--- a/internal/tui/wizard/model_selector_paste_test.go
+++ b/internal/tui/wizard/model_selector_paste_test.go
@@ -137,6 +137,7 @@ func TestModelSelectorStep_Paste_SingleLine_NoChange(t *testing.T) {
 func TestModelSelectorStep_Paste_EmptyContent(t *testing.T) {
 	step := NewModelSelectorStep()
 	step.loading = false
+	step.searchInput.Focus() // Focus the search input
 
 	// Paste empty content
 	pasteMsg := tea.PasteMsg{Content: ""}

--- a/specs/README.md
+++ b/specs/README.md
@@ -3,6 +3,7 @@
 <!-- SPECS -->
 | Name | Description | Date |
 |------|-------------|------|
+| [paste from clipboard](paste-from-clipboard.md) | I want to be able to paste text from the os system clipboard into ANY input/textarea in any compo... | 2026-02-06 |
 | [iteratr](./iteratr.md) | AI coding agent orchestrator with embedded NATS and TUI | 2026-02-02 |
 | [managed-process-migration](./managed-process-migration.md) | Replace ACP with managed process for model selection | 2026-02-02 |
 | [tui-beautification](./tui-beautification.md) | Modernize TUI with Crush patterns, Ultraviolet layouts, component interfaces | 2026-02-02 |

--- a/specs/paste-from-clipboard.md
+++ b/specs/paste-from-clipboard.md
@@ -1,0 +1,149 @@
+## Overview
+
+Enable paste-from-clipboard in every text input/textarea across the entire app. Fix message routing so `tea.PasteMsg` reaches focused inputs in modals and wizards. Add paste sanitization, single-line newline stripping, char limit truncation with toast notification.
+
+## User Story
+
+As a user, I want to paste text from my OS clipboard into any input field (task modal, note modal, chat input, wizard fields) so I can quickly enter pre-composed content without retyping.
+
+## Requirements
+
+- **R1**: `tea.PasteMsg` must reach the focused textarea/textinput in ALL contexts: dashboard, modals (task, note, subagent), wizards (setup, spec)
+- **R2**: Pasting multi-line text into single-line inputs → collapse all newlines to single space
+- **R3**: Pasted text exceeding char limits → truncate to fit, show toast notification ("N chars truncated")
+- **R4**: Sanitize pasted content: strip ANSI escapes, null bytes, non-printable control chars (keep newlines/tabs), normalize CRLF→LF, trim trailing whitespace
+- **R5**: Paste is no-op when non-text element (button, selector) is focused
+- **R6**: Minimal toast component for truncation feedback: bottom-right overlay, auto-dismiss 3s
+- **R7**: Routing fix only (bracketed paste) — no ctrl+v/tea.ReadClipboard() fallback
+- **R8**: No copy-to-clipboard support (separate feature)
+
+## Technical Implementation
+
+### Root Cause
+
+`App.Update` (app.go:131) switches on `msg.(type)`. `tea.KeyPressMsg` routes to `handleKeyPress()` which has the 9-level priority hierarchy including modal forwarding (lines 496-503). But `tea.PasteMsg` is a different type — it falls to the default case (line 390) which only forwards to `dashboard.Update()`, **skipping modals and wizards entirely**.
+
+### Fix: Add PasteMsg Routing in App.Update
+
+Add a `tea.PasteMsg` case in `App.Update` that mirrors the modal/component priority from `handleKeyPress`:
+
+```
+case tea.PasteMsg:
+    1. Sanitize content (strip control chars, normalize CRLF, trim)
+    2. If noteInputModal visible → forward to noteInputModal.Update(sanitized)
+    3. If taskInputModal visible → forward to taskInputModal.Update(sanitized)
+    4. If subagentModal visible → forward to subagentModal.Update(sanitized)
+    5. If logsVisible → no-op (no text input in logs)
+    6. Else → forward to dashboard.Update(sanitized)
+```
+
+### Paste Sanitization (new helper)
+
+`internal/tui/paste.go` — `sanitizePaste(content string) string`:
+- Strip ANSI escape sequences (`\x1b\[...m` etc.)
+- Remove null bytes and non-printable control chars (except `\n`, `\t`, `\r`)
+- Normalize `\r\n` → `\n`
+- Trim trailing whitespace
+
+### Single-line Newline Collapsing
+
+In each `textinput.Model` wrapper's Update handler, intercept `tea.PasteMsg` and collapse newlines before forwarding to the Bubbles component:
+- Replace `\n+` with single space
+- Applies to: agent chat input, model selector search, config step inputs, title step input
+
+### Char Limit Truncation + Toast
+
+In each textarea/textinput wrapper's Update handler:
+- Before forwarding PasteMsg to Bubbles component, check if `len(existing) + len(paste) > charLimit`
+- If exceeding: truncate paste content, emit `ShowToastMsg{Text: "N chars truncated"}`
+- Forward truncated content to Bubbles component
+
+### Toast Component
+
+`internal/tui/toast.go` — minimal overlay:
+- Single message string, auto-dismiss after 3s via `tea.Tick`
+- Rendered bottom-right of screen, above status bar
+- `Show(msg string)` / `Update(msg)` / `View(width, height) string`
+- Composed into `App.View()` as overlay
+
+### Affected Components
+
+| Component | File | Type | Changes needed |
+|-----------|------|------|----------------|
+| App | app.go | Router | Add PasteMsg case with modal priority routing |
+| TaskInputModal | task_input_modal.go | textarea | Handle PasteMsg when focusTextarea, truncate+toast |
+| NoteInputModal | note_input_modal.go | textarea | Handle PasteMsg when focusTextarea, truncate+toast |
+| AgentOutput | agent.go | textinput | Collapse newlines in PasteMsg before forwarding |
+| Dashboard | dashboard.go | Router | Forward PasteMsg to focused pane |
+| DescriptionStep | specwizard/description_step.go | textarea | Truncate+toast |
+| TitleStep | specwizard/title_step.go | textinput | Collapse newlines |
+| ModelSelectorStep | wizard/model_selector.go | textinput | Collapse newlines |
+| ConfigStep | wizard/config_step.go | textinput | Collapse newlines |
+
+## Tasks
+
+### 1. Paste sanitization helper
+- [ ] [P0] Create `internal/tui/paste.go` with `sanitizePaste(string) string` — strip ANSI escapes, null bytes, non-printable control chars, normalize CRLF→LF, trim trailing whitespace
+- [ ] [P0] Create `internal/tui/paste_test.go` — unit tests for ANSI stripping, null byte removal, CRLF normalization, trailing whitespace trimming, preserving valid newlines/tabs
+
+### 2. Add PasteMsg routing in App.Update
+- [ ] [P0] Add `tea.PasteMsg` case in `App.Update` switch (app.go) — sanitize content, route to visible modal first, then dashboard (mirror handleKeyPress priority order)
+- [ ] [P1] Add unit test verifying PasteMsg reaches noteInputModal when visible
+- [ ] [P1] Add unit test verifying PasteMsg reaches taskInputModal when visible
+- [ ] [P1] Add unit test verifying PasteMsg reaches dashboard when no modal visible
+
+### 3. Single-line newline collapsing
+- [ ] [P1] In `AgentOutput.Update` (agent.go) — intercept PasteMsg, collapse `\n+` to single space before forwarding to textinput
+- [ ] [P2] In `ModelSelectorStep.Update` (wizard/model_selector.go) — same newline collapsing
+- [ ] [P2] In `ConfigStep.Update` (wizard/config_step.go) — same newline collapsing for both inputs
+- [ ] [P2] In `TitleStep.Update` (specwizard/title_step.go) — same newline collapsing
+- [ ] [P1] Unit tests for newline collapsing in single-line inputs (agent input + one wizard input)
+
+### 4. Minimal toast component
+- [ ] [P1] Create `internal/tui/toast.go` — toast model with Show(msg), Update(tick), View(w,h), auto-dismiss after 3s
+- [ ] [P1] Create `internal/tui/toast_test.go` — unit tests for show/dismiss timing, rendering
+- [ ] [P1] Integrate toast into App: add field, compose in View() as bottom-right overlay, forward tick msgs
+
+### 5. Char limit truncation with toast
+- [ ] [P1] In `TaskInputModal.Update` — intercept PasteMsg when focusTextarea, check char limit (500), truncate + emit ShowToastMsg if exceeded, forward to textarea
+- [ ] [P1] In `NoteInputModal.Update` — same truncation logic (500 char limit)
+- [ ] [P2] In `DescriptionStep.Update` — same truncation logic (5000 char limit)
+- [ ] [P1] Unit tests for truncation in task modal (paste within limit, paste exceeding limit, paste into partially filled textarea)
+
+### 6. Integration tests
+- [ ] [P2] teatest integration test: paste into task modal textarea, verify content appears
+- [ ] [P2] teatest integration test: paste multi-line into agent chat input, verify newlines collapsed
+- [ ] [P2] teatest integration test: paste exceeding char limit, verify truncation + toast appears
+
+## UI Mockup
+
+Normal paste — no visible change, text appears at cursor in focused input.
+
+Truncation toast (bottom-right, above status bar):
+```
+┌─────────────────────────────────────────────────┐
+│                                                 │
+│  [main app content]                             │
+│                                                 │
+│                                                 │
+│                         ┌──────────────────────┐│
+│                         │ 142 chars truncated  ││
+│                         └──────────────────────┘│
+│ [status bar]                                    │
+└─────────────────────────────────────────────────┘
+```
+Toast auto-dismisses after 3 seconds.
+
+## Out of Scope
+
+- Copy-to-clipboard (ctrl+c / tea.SetClipboard) — separate feature
+- ctrl+v / tea.ReadClipboard() fallback for non-bracketed-paste terminals
+- Paste history or undo-paste
+- Rich text / image paste handling
+- Paste confirmation dialog for large content
+
+## Open Questions
+
+- Should the toast component support severity levels (info/warn/error) for reuse by other features (queue overflow, task creation errors)? Keeping minimal for now but worth considering.
+- Should paste into the agent chat input auto-submit if content ends with a newline? (Current spec: no, just insert)
+- Maximum paste size cap? Currently only char limits per field. Very large clipboard content (e.g., entire file) could cause performance issues in textarea rendering.

--- a/specs/paste-from-clipboard.md
+++ b/specs/paste-from-clipboard.md
@@ -39,7 +39,7 @@ case tea.PasteMsg:
 
 ### Paste Sanitization (new helper)
 
-`internal/tui/paste.go` — `sanitizePaste(content string) string`:
+`internal/tui/paste.go` — `SanitizePaste(content string) string`:
 - Strip ANSI escape sequences (`\x1b\[...m` etc.)
 - Remove null bytes and non-printable control chars (except `\n`, `\t`, `\r`)
 - Normalize `\r\n` → `\n`
@@ -83,7 +83,7 @@ In each textarea/textinput wrapper's Update handler:
 ## Tasks
 
 ### 1. Paste sanitization helper
-- [ ] [P0] Create `internal/tui/paste.go` with `sanitizePaste(string) string` — strip ANSI escapes, null bytes, non-printable control chars, normalize CRLF→LF, trim trailing whitespace
+- [ ] [P0] Create `internal/tui/paste.go` with `SanitizePaste(string) string` — strip ANSI escapes, null bytes, non-printable control chars, normalize CRLF→LF, trim trailing whitespace
 - [ ] [P0] Create `internal/tui/paste_test.go` — unit tests for ANSI stripping, null byte removal, CRLF normalization, trailing whitespace trimming, preserving valid newlines/tabs
 
 ### 2. Add PasteMsg routing in App.Update


### PR DESCRIPTION
## Summary

- Add paste-from-clipboard support (bracketed paste) to every text input/textarea across the app — modals, wizards, dashboard agent input
- Implement paste sanitization (ANSI stripping, null byte removal, CRLF normalization), single-line newline collapsing, char limit truncation with toast notification
- Fix `PasteMsg` routing: add hierarchical priority routing in `App.Update` for modals, and forward `PasteMsg` through `Dashboard.Update` to `AgentOutput` (was silently dropped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paste-from-clipboard across text inputs with sanitization (ANSI, nulls, control chars), CRLF normalization, newline collapsing for single-line fields, and per-field truncation limits with a temporary toast reporting characters removed.
  * Toast UI added for transient messages (auto-dismiss).

* **Tests**
  * Extensive unit and integration tests covering paste routing, sanitization, newline handling, truncation behavior, toast lifecycle and focus-driven behavior.

* **Documentation**
  * Added spec describing paste UX and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->