### PR TITLE
fix(agent): forward provider URL/API key from env vars to KIT

### DIFF
--- a/internal/agent/kitagent.go
+++ b/internal/agent/kitagent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -93,6 +94,22 @@ func (a *KitAgent) Start(ctx context.Context) error {
 		SessionDir: a.workDir,
 		Quiet:      true,
 		SkipConfig: true, // Hermetic: ignore ~/.kit.yml so iteratr behaves consistently
+	}
+
+	// Forward provider overrides from iteratr's own env vars. iteratr uses
+	// SkipConfig: true, which also bypasses viper's env-var setup, so KIT_*
+	// env vars are not auto-read. Read them here and pass through Options.
+	// Precedence: ITERATR_PROVIDER_URL > KIT_PROVIDER_URL (so users can
+	// override KIT's default by being explicit with the iteratr-prefixed var).
+	if v := os.Getenv("ITERATR_PROVIDER_URL"); v != "" {
+		opts.ProviderURL = v
+	} else if v := os.Getenv("KIT_PROVIDER_URL"); v != "" {
+		opts.ProviderURL = v
+	}
+	if v := os.Getenv("ITERATR_PROVIDER_API_KEY"); v != "" {
+		opts.ProviderAPIKey = v
+	} else if v := os.Getenv("KIT_PROVIDER_API_KEY"); v != "" {
+		opts.ProviderAPIKey = v
 	}
 
 	// Configure MCP server if URL provided.


### PR DESCRIPTION
## Problem

`iteratr build` with a custom OpenAI-compatible endpoint (litellm, ollama, vllm, internal proxy, etc.) fails at startup with:

```
failed to start KIT agent: failed to initialize KIT SDK:
unsupported provider: <X> (not found in model database).
```

This fires *before* any HTTP attempt, regardless of whether the URL is reachable.

## Root cause

`internal/agent/kitagent.go:96` passes `SkipConfig: true` to `kit.New()`. That flag bypasses both `.kit.yml` file loading *and* viper's env-var setup — the `SetEnvPrefix("KIT")` + `AutomaticEnv()` calls live inside `initConfig()`, which `SkipConfig: true` skips. So `KIT_PROVIDER_URL` / `KIT_PROVIDER_API_KEY` are silently ignored, and `kit.Options.ProviderURL` is never populated.

The only way for KIT to know the provider URL is from its built-in models.dev registry. Any provider not in that snapshot is unreachable, even though KIT's `custom/<model>` prefix would handle it if `ProviderURL` were set.

The KIT v0.74.1 release notes ("route prefixed models through custom wire when --provider-url is set") imply setting `KIT_PROVIDER_URL` is sufficient — it isn't, because of the `SkipConfig: true` quirk above.

## Fix

Read the env vars directly in `KitAgent.Start()` and pass them through `Options.ProviderURL` / `Options.ProviderAPIKey`. Precedence: `ITERATR_PROVIDER_URL` > `KIT_PROVIDER_URL` (and same for the API key), so the iteratr-prefixed name wins when both are set.

10-line change in `internal/agent/kitagent.go` (plus the `os` import). No SDK bump, no schema change, no env-var defaulting in `iteratr.yml`.

## Usage

```yaml
# iteratr.yml
model: custom/qwen3_5-122b   # was: litellm-poc/qwen3_5-122b
```

```bash
export ITERATR_PROVIDER_URL="http://your-litellm-poc-host/v1"
export ITERATR_PROVIDER_API_KEY="<key>"
iteratr build
```

`KIT_PROVIDER_URL` / `KIT_PROVIDER_API_KEY` (upstream names) also work as a fallback.

## Verified

- Built against KIT v0.63.1 (the version `go.mod` currently pins).
- Smoke test with `model: custom/qwen3_5-122b` + `ITERATR_PROVIDER_URL` set: KIT makes the HTTP POST to the configured URL (got "connection refused" only because I tested against a fake port — proves wire routing works).
- `go vet ./...` clean.
- `go test -race ./...` — all 19 packages pass.

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable support for provider configuration overrides, with fallback options for flexible deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->